### PR TITLE
Fixed [Layout] Months don't fit in view issue #8

### DIFF
--- a/lib/src/dialogs.dart
+++ b/lib/src/dialogs.dart
@@ -287,23 +287,17 @@ class _MonthYearPickerDialogState extends State<MonthYearPickerDialog> {
 
     final picker = LayoutBuilder(
       builder: (context, constraints) {
-        final pickerMaxWidth =
-            _landscapeDialogSize.width - _datePickerHeaderLandscapeWidth;
-        final width = constraints.maxHeight < pickerMaxWidth
-            ? constraints.maxHeight / 3.0 * 4.0
-            : null;
-
         return Stack(
           children: [
             AnimatedPositioned(
               duration: _dialogSizeAnimationDuration,
               curve: Curves.easeOut,
               left: 0.0,
-              right: pickerMaxWidth - (width ?? pickerMaxWidth),
               top: _isShowingYear ? 0.0 : -constraints.maxHeight,
               bottom: _isShowingYear ? 0.0 : constraints.maxHeight,
               child: SizedBox(
                 height: constraints.maxHeight,
+                width: constraints.maxWidth,
                 child: YearPicker(
                   key: _yearPickerState,
                   initialDate: _selectedDate,
@@ -321,11 +315,11 @@ class _MonthYearPickerDialogState extends State<MonthYearPickerDialog> {
               duration: _dialogSizeAnimationDuration,
               curve: Curves.easeOut,
               left: 0.0,
-              right: pickerMaxWidth - (width ?? pickerMaxWidth),
               top: _isShowingYear ? constraints.maxHeight : 0.0,
               bottom: _isShowingYear ? -constraints.maxHeight : 0.0,
               child: SizedBox(
                 height: constraints.maxHeight,
+                width: constraints.maxWidth,
                 child: MonthPicker(
                   key: _monthPickerState,
                   initialDate: _selectedDate,

--- a/lib/src/pickers.dart
+++ b/lib/src/pickers.dart
@@ -127,22 +127,34 @@ class MonthPickerState extends State<MonthPicker> {
   }
 
   Widget _buildItem(final BuildContext context, final int page) {
-    return GridView.count(
-      physics: const NeverScrollableScrollPhysics(),
-      padding: const EdgeInsets.all(8.0),
-      crossAxisCount: 4,
-      children: [
-        for (var i = 0; i < 12; i++)
-          _MonthButton(
-            page: page,
-            index: i,
-            firstDate: widget.firstDate,
-            lastDate: widget.lastDate,
-            selectedDate: widget.selectedDate,
-            onMonthSelected: widget.onMonthSelected,
-            selectableMonthYearPredicate: widget.selectableMonthYearPredicate,
-          ),
-      ],
+    return LayoutBuilder(
+      builder: (context,constraints){
+        const totalItems=12;
+        final crossAxisCount=constraints.maxWidth ~/ (100);
+        final mainAxisCount=totalItems ~/ crossAxisCount;
+        final itemWidget= constraints.maxWidth/crossAxisCount;
+        final itemHeight= constraints.maxHeight/mainAxisCount;
+        return GridView.count(
+          physics: const NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(8.0),
+          crossAxisCount: crossAxisCount,
+          childAspectRatio: itemWidget/itemHeight,
+          children: List<Widget>.generate(totalItems, (index){
+            return Center(
+              child: _MonthButton(
+                page: page,
+                index: index,
+                firstDate: widget.firstDate,
+                lastDate: widget.lastDate,
+                selectedDate: widget.selectedDate,
+                onMonthSelected: widget.onMonthSelected,
+                selectableMonthYearPredicate:
+                widget.selectableMonthYearPredicate,
+              ),
+            );
+          }),
+        );
+      },
     );
   }
 
@@ -281,23 +293,33 @@ class YearPickerState extends State<YearPicker> {
   }
 
   Widget _buildItem(final BuildContext context, final int page) {
-    return GridView.count(
-      physics: const NeverScrollableScrollPhysics(),
-      padding: const EdgeInsets.all(8.0),
-      crossAxisCount: 4,
-      children: [
-        for (var i = 0; i < 12; i++)
-          _YearButton(
-            page: page,
-            index: i,
-            firstDate: widget.firstDate,
-            lastDate: widget.lastDate,
-            selectedDate: widget.selectedDate,
-            onYearSelected: widget.onYearSelected,
-            selectableMonthYearPredicate: widget.selectableMonthYearPredicate,
-          ),
-      ],
+    return LayoutBuilder(
+      builder: (context,constraints){
+        const totalItems=12;
+        final crossAxisCount=constraints.maxWidth ~/ (100);
+        final mainAxisCount=totalItems ~/ crossAxisCount;
+        final itemWidget= constraints.maxWidth/crossAxisCount;
+        final itemHeight= constraints.maxHeight/mainAxisCount;
+        return GridView.count(
+          physics: const NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(8.0),
+          crossAxisCount: crossAxisCount,
+          childAspectRatio: itemWidget/itemHeight,
+          children: List<Widget>.generate(totalItems,(index){
+            return _YearButton(
+              page: page,
+              index: index,
+              firstDate: widget.firstDate,
+              lastDate: widget.lastDate,
+              selectedDate: widget.selectedDate,
+              onYearSelected: widget.onYearSelected,
+              selectableMonthYearPredicate: widget.selectableMonthYearPredicate,
+            );
+          }),
+        );
+      },
     );
+
   }
 
   void _onPageChanged(final int page) {
@@ -473,18 +495,20 @@ class _Button extends StatelessWidget {
             ? colorScheme.secondary
             : colorScheme.onSurface;
 
-    return TextButton(
-      onPressed: isEnabled ? onPressed : null,
-      style: TextButton.styleFrom(
-        backgroundColor: buttonBackground,
-        foregroundColor: buttonText,
-        disabledForegroundColor: buttonText,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(100.0),
+    return InkWell(
+      onTap: isEnabled ? onPressed : null,
+      customBorder: const CircleBorder(),
+      child: Container(
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: buttonBackground,
         ),
-        textStyle: TextStyle(color: buttonText),
+        child: Center(
+            child: Text(label,
+              style: TextStyle(color: buttonText),),
+        ),
       ),
-      child: Text(label),
     );
   }
 


### PR DESCRIPTION
Fixed Size of month and year buttons
Before 
![Simulator Screenshot - iPhone 16 Plus - 2025-01-30 at 17 57 48](https://github.com/user-attachments/assets/d4723b18-201a-4776-9457-bd096ecb8411)
![Simulator Screenshot - iPhone 16 Plus - 2025-01-30 at 17 51 46](https://github.com/user-attachments/assets/f66959cd-dda0-4104-a7fc-c5c440567a97)

After
![Simulator Screenshot - iPhone 16 Plus - 2025-01-30 at 17 52 17](https://github.com/user-attachments/assets/5b3218f3-8d44-466e-9936-fa8b99836f10)
![Simulator Screenshot - iPhone 16 Plus - 2025-01-30 at 17 54 58](https://github.com/user-attachments/assets/9c4259d0-0448-483e-a996-0d15c0f941a4)

Changed the height and width of GridView children to be dynamic.
The buttons are now displayed inside the container